### PR TITLE
Remove hard-coded wPokedexOwned/wPokedexSeen array size

### DIFF
--- a/engine/menu/pokedex.asm
+++ b/engine/menu/pokedex.asm
@@ -194,7 +194,7 @@ HandlePokedexListMenu: ; 40111 (10:4111)
 	call PlaceString
 ; find the highest pokedex number among the pokemon the player has seen
 	ld hl,wPokedexSeenEnd - 1
-	ld b,153
+	ld b,(wPokedexSeenEnd - wPokedexSeen) * 8 + 1
 .maxSeenPokemonLoop
 	ld a,[hld]
 	ld c,8

--- a/scripts/oakslab.asm
+++ b/scripts/oakslab.asm
@@ -944,7 +944,7 @@ OaksLabText5: ; 1d248 (7:5248)
 	bit 6, a
 	jr nz, .asm_50e81 ; 0x1d24e
 	ld hl, wPokedexOwned
-	ld b, $13
+	ld b, wPokedexOwnedEnd - wPokedexOwned
 	call CountSetBits
 	ld a, [wd11e]
 	cp $2


### PR DESCRIPTION
This should automatically fix the last of the problems encountered with adding new Pokemon